### PR TITLE
limiter: don't return a negative amount of allowed bytes

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -32,7 +32,11 @@ func newRateLimiter(perSec int, maxBurst time.Duration) *rateLimiter {
 
 func (r *rateLimiter) CanDo() (canDo int) {
 	perBatch := atomic.LoadInt64(&r.maxPerBatch)
-	return int(perBatch - r.batchDone)
+	canDo = int(perBatch - r.batchDone)
+	if canDo < 0 {
+		return 0
+	}
+	return canDo
 }
 
 func (r *rateLimiter) Did(n int) {

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -1,0 +1,16 @@
+package iocontrol
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLimiterCanDo(t *testing.T) {
+	limiter := newRateLimiter(3*MiB, time.Second)
+	limiter.Did(2 * MiB)     // simulate writing
+	limiter.SetRate(1 * MiB) // limiter is now less than we've written so far
+	canDo := limiter.CanDo()
+	if canDo != 0 {
+		t.Fatalf("wanted to be able to write nothing, got: %d", canDo)
+	}
+}


### PR DESCRIPTION
The bug looks like this:

1. We have a pool where we're allowed to write 10MB in 1 second
2. We have two writers, 1 and 2. Each of them can write 5MB this period. 
3. Each of them write 4 MB.
4. We borrow another writer, 3. 
5. We assign, in `limiter.go` the amount that writers 1 and 2 are allowed to write in this period. It's not 5MB any more, it's 3.33MB. 
6. Writer 1 calls for the amount it's allowed to write, which is now negative .66 MB. This causes a panic.

Basically, this results from the amount of data we _actually_ sent being more  than what we thought we were allowed to do in this period, so we would return a negative amount for what we are allowed to do next time. 

@macb 