### PR TITLE
Profiler of io.Reader/io.Writer pairs.

### DIFF
--- a/stream_profile.go
+++ b/stream_profile.go
@@ -8,9 +8,9 @@ import (
 	"github.com/benbjohnson/clock"
 )
 
-// StreamProfile contains information about the timings involved in
+// TimeProfile contains information about the timings involved in
 // the exchange of bytes between an io.Writer and io.Reader.
-type StreamProfile struct {
+type TimeProfile struct {
 	WaitRead  time.Duration
 	WaitWrite time.Duration
 	Total     time.Duration
@@ -20,18 +20,22 @@ type StreamProfile struct {
 // time is spent: writing or reading. The result is returned when
 // the `done` func is called. The `done` func can be called multiple
 // times.
-func Profile(w io.Writer, r io.Reader) (pw io.Writer, pr io.Reader, done func() StreamProfile) {
+//
+// There is a small performance overhead of ~µs per Read/Write call.
+// This is negligible in most I/O workload. If the overhead is too
+// much for your needs, use the `ProfileSample` call.
+func Profile(w io.Writer, r io.Reader) (pw io.Writer, pr io.Reader, done func() TimeProfile) {
 	return profile(clock.New(), w, r)
 }
 
-func profile(clk clock.Clock, w io.Writer, r io.Reader) (io.Writer, io.Reader, func() StreamProfile) {
+func profile(clk clock.Clock, w io.Writer, r io.Reader) (io.Writer, io.Reader, func() TimeProfile) {
 
 	preciseWriter := &preciseTimedWriter{clk: clk, w: w}
 	preciseReader := &preciseTimedReader{clk: clk, r: r}
 
 	start := clk.Now()
-	return preciseWriter, preciseReader, func() StreamProfile {
-		return StreamProfile{
+	return preciseWriter, preciseReader, func() TimeProfile {
+		return TimeProfile{
 			Total:     clk.Now().Sub(start),
 			WaitRead:  preciseReader.WaitRead(),
 			WaitWrite: preciseWriter.WaitWrite(),
@@ -70,5 +74,106 @@ func (t *preciseTimedWriter) Write(p []byte) (int, error) {
 	start := t.clk.Now()
 	n, err := t.w.Write(p)
 	atomic.AddInt64(&t.sumNS, t.clk.Now().Sub(start).Nanoseconds())
+	return n, err
+}
+
+// sampling, high performance profiler
+
+const (
+	state_runtime uint32 = iota
+	state_blocked
+)
+
+// ProfileSample will wrap a writer and reader pair and collect
+// samples of where time is spent: writing or reading. The result
+// is an approximation that is returned when the `done` func is
+// called. The `done` func can be called *only once*.
+//
+// This call is not as precise as the `Profile` call, but the
+// performance overhead is much reduced.
+func ProfileSample(w io.Writer, r io.Reader, res time.Duration) (pw io.Writer, pr io.Reader, done func() SamplingProfile) {
+	return profileSample(clock.New(), w, r, res)
+}
+
+// SamplingProfile samples when a reader and a writer are blocked, or not.
+// If sampled at a high enough resolution, the result should give a good
+// approximation of the distribution of time. The results are not as
+// precise as the result of `Profile`, but the performance overhead
+// is much reduced.
+type SamplingProfile struct {
+	TimeProfile
+	Reading    int
+	Writing    int
+	NotReading int
+	NotWriting int
+}
+
+func profileSample(clk clock.Clock, w io.Writer, r io.Reader, res time.Duration) (io.Writer, io.Reader, func() SamplingProfile) {
+	samplingWriter := &samplingTimeWriter{w: w}
+	samplingReader := &samplingTimeReader{r: r}
+
+	start := clk.Now()
+	done := make(chan struct{})
+
+	samples := SamplingProfile{}
+	go func() {
+		ticker := clk.Ticker(res)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+
+				isWriting := atomic.LoadUint32(&samplingWriter.state) == state_blocked
+				isReading := atomic.LoadUint32(&samplingReader.state) == state_blocked
+
+				if isWriting {
+					samples.Writing++
+				} else {
+					samples.NotWriting++
+				}
+				if isReading {
+					samples.Reading++
+				} else {
+					samples.NotReading++
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	return samplingWriter, samplingReader, func() SamplingProfile {
+		close(done)
+		total := clk.Now().Sub(start)
+		samples.TimeProfile = TimeProfile{
+			Total:     total,
+			WaitRead:  time.Duration(float64(samples.Reading) / float64(samples.Reading+samples.NotReading) * float64(total)),
+			WaitWrite: time.Duration(float64(samples.Writing) / float64(samples.Writing+samples.NotWriting) * float64(total)),
+		}
+		return samples
+	}
+}
+
+type samplingTimeReader struct {
+	state uint32
+	r     io.Reader
+}
+
+func (s *samplingTimeReader) Read(p []byte) (int, error) {
+	atomic.StoreUint32(&s.state, state_blocked)
+	n, err := s.r.Read(p)
+	atomic.StoreUint32(&s.state, state_runtime)
+	return n, err
+}
+
+type samplingTimeWriter struct {
+	state uint32
+	w     io.Writer
+}
+
+func (s *samplingTimeWriter) Write(p []byte) (int, error) {
+	atomic.StoreUint32(&s.state, state_blocked)
+	n, err := s.w.Write(p)
+	atomic.StoreUint32(&s.state, state_runtime)
 	return n, err
 }

--- a/stream_profile.go
+++ b/stream_profile.go
@@ -1,0 +1,74 @@
+package iocontrol
+
+import (
+	"io"
+	"sync/atomic"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// StreamProfile contains information about the timings involved in
+// the exchange of bytes between an io.Writer and io.Reader.
+type StreamProfile struct {
+	WaitRead  time.Duration
+	WaitWrite time.Duration
+	Total     time.Duration
+}
+
+// Profile will wrap a writer and reader pair and profile where
+// time is spent: writing or reading. The result is returned when
+// the `done` func is called. The `done` func can be called multiple
+// times.
+func Profile(w io.Writer, r io.Reader) (pw io.Writer, pr io.Reader, done func() StreamProfile) {
+	return profile(clock.New(), w, r)
+}
+
+func profile(clk clock.Clock, w io.Writer, r io.Reader) (io.Writer, io.Reader, func() StreamProfile) {
+
+	preciseWriter := &preciseTimedWriter{clk: clk, w: w}
+	preciseReader := &preciseTimedReader{clk: clk, r: r}
+
+	start := clk.Now()
+	return preciseWriter, preciseReader, func() StreamProfile {
+		return StreamProfile{
+			Total:     clk.Now().Sub(start),
+			WaitRead:  preciseReader.WaitRead(),
+			WaitWrite: preciseWriter.WaitWrite(),
+		}
+	}
+}
+
+type preciseTimedReader struct {
+	clk   clock.Clock
+	r     io.Reader
+	sumNS int64
+}
+
+func (t *preciseTimedReader) WaitRead() time.Duration {
+	return time.Duration(atomic.LoadInt64(&t.sumNS))
+}
+
+func (t *preciseTimedReader) Read(p []byte) (int, error) {
+	start := t.clk.Now()
+	n, err := t.r.Read(p)
+	atomic.AddInt64(&t.sumNS, t.clk.Now().Sub(start).Nanoseconds())
+	return n, err
+}
+
+type preciseTimedWriter struct {
+	clk   clock.Clock
+	w     io.Writer
+	sumNS int64
+}
+
+func (t *preciseTimedWriter) WaitWrite() time.Duration {
+	return time.Duration(atomic.LoadInt64(&t.sumNS))
+}
+
+func (t *preciseTimedWriter) Write(p []byte) (int, error) {
+	start := t.clk.Now()
+	n, err := t.w.Write(p)
+	atomic.AddInt64(&t.sumNS, t.clk.Now().Sub(start).Nanoseconds())
+	return n, err
+}

--- a/stream_profile.go
+++ b/stream_profile.go
@@ -22,7 +22,7 @@ type TimeProfile struct {
 // times.
 //
 // There is a small performance overhead of ~µs per Read/Write call.
-// This is negligible in most I/O workload. If the overhead is too
+// This is negligible in most I/O workloads. If the overhead is too
 // much for your needs, use the `ProfileSample` call.
 func Profile(w io.Writer, r io.Reader) (pw io.Writer, pr io.Reader, done func() TimeProfile) {
 	return profile(clock.New(), w, r)
@@ -80,8 +80,8 @@ func (t *preciseTimedWriter) Write(p []byte) (int, error) {
 // sampling, high performance profiler
 
 const (
-	state_runtime uint32 = iota
-	state_blocked
+	stateRuntime uint32 = iota
+	stateBlocked
 )
 
 // ProfileSample will wrap a writer and reader pair and collect
@@ -123,8 +123,8 @@ func profileSample(clk clock.Clock, w io.Writer, r io.Reader, res time.Duration)
 			select {
 			case <-ticker.C:
 
-				isWriting := atomic.LoadUint32(&samplingWriter.state) == state_blocked
-				isReading := atomic.LoadUint32(&samplingReader.state) == state_blocked
+				isWriting := atomic.LoadUint32(&samplingWriter.state) == stateBlocked
+				isReading := atomic.LoadUint32(&samplingReader.state) == stateBlocked
 
 				if isWriting {
 					samples.Writing++
@@ -160,9 +160,9 @@ type samplingTimeReader struct {
 }
 
 func (s *samplingTimeReader) Read(p []byte) (int, error) {
-	atomic.StoreUint32(&s.state, state_blocked)
+	atomic.StoreUint32(&s.state, stateBlocked)
 	n, err := s.r.Read(p)
-	atomic.StoreUint32(&s.state, state_runtime)
+	atomic.StoreUint32(&s.state, stateRuntime)
 	return n, err
 }
 
@@ -172,8 +172,8 @@ type samplingTimeWriter struct {
 }
 
 func (s *samplingTimeWriter) Write(p []byte) (int, error) {
-	atomic.StoreUint32(&s.state, state_blocked)
+	atomic.StoreUint32(&s.state, stateBlocked)
 	n, err := s.w.Write(p)
-	atomic.StoreUint32(&s.state, state_runtime)
+	atomic.StoreUint32(&s.state, stateRuntime)
 	return n, err
 }

--- a/stream_profile_test.go
+++ b/stream_profile_test.go
@@ -1,0 +1,72 @@
+package iocontrol
+
+import (
+	"io"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+func TestProfile(t *testing.T) {
+
+	wantProfile := StreamProfile{
+		Total:     2 * time.Second,
+		WaitRead:  500 * time.Millisecond,
+		WaitWrite: 1500 * time.Millisecond,
+	}
+	clk := clock.NewMock()
+
+	start := clk.Now()
+
+	sleepRead := readFunc(func(p []byte) (int, error) {
+		var err error
+		if clk.Now().Sub(start) >= wantProfile.Total {
+			err = io.EOF
+		}
+		clk.Sleep(wantProfile.WaitRead / 1000)
+		return len(p), err
+	})
+
+	sleepWrite := writeFunc(func(p []byte) (int, error) {
+		clk.Sleep(wantProfile.WaitWrite / 1000)
+		return len(p), nil
+	})
+
+	res := make(chan StreamProfile, 1)
+	go func() {
+		w, r, done := profile(clk, sleepWrite, sleepRead)
+		io.Copy(w, r)
+		res <- done()
+	}()
+
+	var gotProfile StreamProfile
+loop:
+	for {
+		select {
+		case gotProfile = <-res:
+			break loop
+		default:
+			clk.Add(1 * time.Millisecond)
+		}
+	}
+
+	wantReadRatio := float64(wantProfile.WaitRead) / float64(wantProfile.WaitRead+wantProfile.WaitWrite)
+	gotReadRatio := float64(gotProfile.WaitRead) / float64(gotProfile.WaitRead+gotProfile.WaitWrite)
+
+	diff := (math.Max(wantReadRatio, gotReadRatio) - math.Min(wantReadRatio, gotReadRatio)) / math.Max(wantReadRatio, gotReadRatio)
+	if diff > 0.05 {
+		t.Logf("want=%#v", wantProfile)
+		t.Logf(" got=%#v", gotProfile)
+		t.Fatalf("profiles are too different: %.2f%% different", 100*diff)
+	}
+}
+
+type readFunc func([]byte) (int, error)
+
+func (r readFunc) Read(p []byte) (int, error) { return r(p) }
+
+type writeFunc func([]byte) (int, error)
+
+func (w writeFunc) Write(p []byte) (int, error) { return w(p) }

--- a/stream_profile_test.go
+++ b/stream_profile_test.go
@@ -1,7 +1,9 @@
 package iocontrol
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
 	"math"
 	"testing"
 	"time"
@@ -11,7 +13,7 @@ import (
 
 func TestProfile(t *testing.T) {
 
-	wantProfile := StreamProfile{
+	wantProfile := TimeProfile{
 		Total:     2 * time.Second,
 		WaitRead:  500 * time.Millisecond,
 		WaitWrite: 1500 * time.Millisecond,
@@ -34,14 +36,14 @@ func TestProfile(t *testing.T) {
 		return len(p), nil
 	})
 
-	res := make(chan StreamProfile, 1)
+	res := make(chan TimeProfile, 1)
 	go func() {
 		w, r, done := profile(clk, sleepWrite, sleepRead)
 		io.Copy(w, r)
 		res <- done()
 	}()
 
-	var gotProfile StreamProfile
+	var gotProfile TimeProfile
 loop:
 	for {
 		select {
@@ -60,6 +62,87 @@ loop:
 		t.Logf("want=%#v", wantProfile)
 		t.Logf(" got=%#v", gotProfile)
 		t.Fatalf("profiles are too different: %.2f%% different", 100*diff)
+	}
+}
+
+func TestProfileSample(t *testing.T) {
+
+	wantProfile := TimeProfile{
+		Total:     2 * time.Second,
+		WaitRead:  500 * time.Millisecond,
+		WaitWrite: 1500 * time.Millisecond,
+	}
+	clk := clock.NewMock()
+
+	start := clk.Now()
+
+	sleepRead := readFunc(func(p []byte) (int, error) {
+		var err error
+		if clk.Now().Sub(start) >= wantProfile.Total {
+			err = io.EOF
+		}
+		clk.Sleep(wantProfile.WaitRead / 1000)
+		return len(p), err
+	})
+
+	sleepWrite := writeFunc(func(p []byte) (int, error) {
+		clk.Sleep(wantProfile.WaitWrite / 1000)
+		return len(p), nil
+	})
+
+	res := make(chan TimeProfile, 1)
+	go func() {
+		w, r, done := profileSample(clk, sleepWrite, sleepRead, time.Millisecond)
+		io.Copy(w, r)
+		res <- done().TimeProfile
+	}()
+
+	var gotProfile TimeProfile
+loop:
+	for {
+		select {
+		case gotProfile = <-res:
+			break loop
+		default:
+			clk.Add(1 * time.Millisecond)
+		}
+	}
+
+	wantReadRatio := float64(wantProfile.WaitRead) / float64(wantProfile.WaitRead+wantProfile.WaitWrite)
+	gotReadRatio := float64(gotProfile.WaitRead) / float64(gotProfile.WaitRead+gotProfile.WaitWrite)
+
+	diff := (math.Max(wantReadRatio, gotReadRatio) - math.Min(wantReadRatio, gotReadRatio)) / math.Max(wantReadRatio, gotReadRatio)
+	if diff > 0.05 {
+		t.Logf("want=%#v", wantProfile)
+		t.Logf(" got=%#v", gotProfile)
+		t.Fatalf("profiles are too different: %.2f%% different", 100*diff)
+	}
+}
+
+func BenchmarkNoProfile(b *testing.B) {
+
+	reader := bytes.NewReader(make([]byte, 1<<30))
+	writer := ioutil.Discard
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		io.Copy(writer, reader)
+	}
+}
+
+func BenchmarkProfile(b *testing.B) {
+
+	reader := bytes.NewReader(make([]byte, 1<<30))
+	writer := ioutil.Discard
+
+	pwriter, preader, done := Profile(writer, reader)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		io.Copy(pwriter, preader)
+		done()
 	}
 }
 


### PR DESCRIPTION
The main use case for this addition is when you're streaming data from an `io.Reader` to an `io.Writer`, and you want to know what's slow:

- the `io.Reader`?
- the `io.Writer`?
- nothing, it's the app?

so

```go
io.Copy(w, r)
```
becomes:
```go
pw, pr, prof := iocontrol.Profile(w, r)
io.Copy(pw, pr)
profile := prof()
// profile.WaitRead
// profile.WaitWrite
```

Then you can expose that as metrics in other places, like to know if a cache is slow because the app pulling from it is slow to accept the bytes.

@nickvanw @macb @Mattkanwisher @mdlayher @jphines