### PR TITLE
Fix compile error: invalid value "go1" for -lang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aybabtme/iocontrol
 
-go 1.0
+go 1.21
 
 require (
 	github.com/benbjohnson/clock v1.3.3


### PR DESCRIPTION
Go version 1.22 reports this error during compile.