### PR TITLE
Fix the golang version build failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aybabtme/iocontrol
 
-go 1.0
+go 1.12.0
 
 require (
 	github.com/benbjohnson/clock v1.3.3


### PR DESCRIPTION
The PR is an attempt to fix the error that causing build failure in our application...

```
go test -race ./... -v
# github.com/aybabtme/iocontrol
compile: invalid value "go1" for -lang: should be something like "go1.12"
```

I realize that upgrading the `go.mod` to `1.12.0` as directed in the compile error seems to solve it for now.
